### PR TITLE
Testcase logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Don't track testcase output/logs
-build/
+build*/
+build

--- a/maintest.sh
+++ b/maintest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 if ! oc whoami; then
     echo "Must login using oc before running"
     exit 1


### PR DESCRIPTION
Added log structure and logging to the maintest.sh.  Also added logging history of previous sandbox executions of maintest.sh.  build symlink always linked to the latest execution.  

```[kevin@svtauto462551-controller-1 kabanero-regression-testing-master]$ ll
total 8
lrwxrwxrwx 1 kevin kevin   70 May 12 13:42 build -> /home/kevin/kabanero-regression-testing-master/build_2020-05-12_134254
drwxrwxr-x 3 kevin kevin   31 May 12 13:16 build_2020-05-12_131606
drwxrwxr-x 3 kevin kevin   31 May 12 13:16 build_2020-05-12_131639
drwxrwxr-x 3 kevin kevin   31 May 12 13:19 build_2020-05-12_131903
drwxrwxr-x 3 kevin kevin   31 May 12 13:19 build_2020-05-12_131921
drwxrwxr-x 4 kevin kevin   53 May 12 13:43 build_2020-05-12_134254
-rwxr-xr-x 1 kevin kevin 2072 May 12 13:40 maintest.sh
-rw-rw-r-- 1 kevin kevin  995 May  6 07:43 README.md
drwxrwxr-x 2 kevin kevin   58 May  6 07:43 scripts
drwxrwxr-x 4 kevin kevin   87 May  6 07:43 tests
```

Logging structure:
```
build
├── kabanero-debug
....
└── kabanero-operator
    └── 00-credentials
        ├── output
        ├── PASSED.TXT
        └── results
            ├── 00-credentials.sh.stderr.txt
            └── 00-credentials.sh.stdout.txt
```